### PR TITLE
Tweaks to technical features

### DIFF
--- a/technical-features.qmd
+++ b/technical-features.qmd
@@ -7,15 +7,16 @@ subtitle: Additional information on technical features and their maturity levels
 
 **Current mature implementations share the following characteristics:**
 
-- Consistent spatial and temporal resolution across each variable
-- Uniform chunk grid and compression scheme across each variable
-- Chunk manifest generated at collection level, spanning many granules
+- Virtual datasets are used to provide alternate views into data, with views ranging from the entire collection, to subsets of a collection, to subsets of a granule.
+- Consistent spatial and temporal resolution across each variable within a view
+- Uniform chunk grid and compression scheme across each variable within a view
+- Chunk manifest are generated for a particular view and may span many granules
 
 ## Developing Support
 
 ## Non-uniform grids
 
-Some NASA collections present additional complexity due having varying compression schemes and chunk grids across a logical array (usually across granules). At this point in time, Zarr assumes consistent chunk shape and compression across the entire array. 
+Some NASA collections present additional complexity due having varying compression schemes and chunk grids across a logical array (usually across granules). At this point in time, Zarr assumes consistent chunk shape and compression across the entire array.
 
 However, support for both varying chunk shapes and compression schemes is in active development and should be available by summer 2026.
 
@@ -25,7 +26,7 @@ COMING SOON
 
 # No plans for support
 
-## Unsupported data formats
+## Supported data formats
 
 Data format support is limited to formats with VirtualiZarr parser implementations.
 
@@ -37,7 +38,7 @@ Parsers maintained by VirtualiZarr include:
 * [FITSParser](https://github.com/zarr-developers/VirtualiZarr/blob/main/virtualizarr/parsers/fits.py)
 * [NetCDF3Parser](https://github.com/zarr-developers/VirtualiZarr/blob/main/virtualizarr/parsers/netcdf3.py)
 * [ZarrParser](https://github.com/zarr-developers/VirtualiZarr/blob/main/virtualizarr/parsers/zarr.py)
-  
+
 Parsers maintained outside of VirtualiZarr include:
 
 * [virtual-tiff](https://virtual-tiff.readthedocs.io/en/latest/)

--- a/technical-features.qmd
+++ b/technical-features.qmd
@@ -10,10 +10,9 @@ subtitle: Additional information on technical features and their maturity levels
 - Virtual stores are used to provide alternate views (defined below) into the data. These views can range from an entire collection, to subsets of a collection, to a subset of a granule.
 - Consistent spatial and temporal resolution across each variable (i.e. array) within a virtual store
 - Uniform chunk grid and compression scheme across each variable within a virtual store
-- Chunk manifests are generated for a particular view and may span many granules
 
 ::: {.callout-note}
-We define the term "view" in a virtual store context to mean the different ways the same dataset can be represented. For example, a view of the same dataset could be representing the entire dataset as a cube or some a subset of the dataset, or a single variable array or a data tree of multiple groups of arrays. Different views will make sense given a datasets characteristics and the intended use cases.
+We define the term "view" in a virtual store context to mean the different ways the same dataset can be represented. A view of the same dataset could be representing the entire dataset as a cube or aggregating some a subset of the dataset. Different views will make sense for any particular dataset given its characteristics and the intended use cases; see [Virtual Stores at NASA](nasa-applications.qmd) for some real-world examples.
 :::
 
 ## Supported data formats

--- a/technical-features.qmd
+++ b/technical-features.qmd
@@ -3,7 +3,7 @@ title: "Technical Features"
 subtitle: Additional information on technical features and their maturity levels
 ---
 
-## Mature Support
+# Mature Support
 
 **Current mature implementations share the following characteristics:**
 
@@ -12,25 +12,9 @@ subtitle: Additional information on technical features and their maturity levels
 - Uniform chunk grid and compression scheme across each variable within a view
 - Chunk manifest are generated for a particular view and may span many granules
 
-## Developing Support
-
-## Non-uniform grids
-
-Some NASA collections present additional complexity due having varying compression schemes and chunk grids across a logical array (usually across granules). At this point in time, Zarr assumes consistent chunk shape and compression across the entire array.
-
-However, support for both varying chunk shapes and compression schemes is in active development and should be available by summer 2026.
-
-## Non-cubable data
-
-COMING SOON
-
-# No plans for support
-
 ## Supported data formats
 
-Data format support is limited to formats with VirtualiZarr parser implementations.
-
-Parsers maintained by VirtualiZarr include:
+Data format support is limited to formats with VirtualiZarr parser implementations. Parsers maintained by VirtualiZarr include:
 
 * [HDFParser](https://github.com/zarr-developers/VirtualiZarr/blob/main/virtualizarr/parsers/hdf/hdf.py)
 * [Kerchunk (Parquet or JSON)](https://github.com/zarr-developers/VirtualiZarr/tree/main/virtualizarr/parsers/kerchunk)
@@ -45,3 +29,19 @@ Parsers maintained outside of VirtualiZarr include:
 * [hrrr-parser](https://github.com/virtual-zarr/hrrr-parser)
 
 Custom parsers for additional formats can be implemented using the VirtualiZarr [CustomParsers](https://virtualizarr.readthedocs.io/en/stable/custom_parsers.html) guide.
+
+# Developing Support
+
+## Non-uniform grids
+
+Some NASA collections present additional complexity due having varying compression schemes and chunk grids across a logical array (usually across granules). At this point in time, Zarr assumes consistent chunk shape and compression across the entire array.
+
+However, support for both varying chunk shapes and compression schemes is in active development and should be available by summer 2026.
+
+## Non-cubable data
+
+COMING SOON
+
+# No plans for support
+
+* There are no plans to support formats outside of the "Supported data formats" list above at this time.

--- a/technical-features.qmd
+++ b/technical-features.qmd
@@ -7,9 +7,9 @@ subtitle: Additional information on technical features and their maturity levels
 
 **Current mature implementations share the following characteristics:**
 
-- Virtual datasets are used to provide alternate views into data, with views ranging from the entire collection, to subsets of a collection, to subsets of a granule.
-- Consistent spatial and temporal resolution across each variable within a view
-- Uniform chunk grid and compression scheme across each variable within a view
+- Virtual stores are used to provide alternate views into data. These views can range from an entire collection, to subsets of a collection, to subsets of a granule.
+- Consistent spatial and temporal resolution across each variable (i.e. array) within a virtual store
+- Uniform chunk grid and compression scheme across each variable within a virtual store
 - Chunk manifest are generated for a particular view and may span many granules
 
 ## Supported data formats

--- a/technical-features.qmd
+++ b/technical-features.qmd
@@ -7,7 +7,7 @@ subtitle: Additional information on technical features and their maturity levels
 
 **Current mature implementations share the following characteristics:**
 
-- Virtual stores are used to provide alternate views (defined below) into the data. These views can range from an entire collection, to subsets of a collection, to subsets of a granule.
+- Virtual stores are used to provide alternate views (defined below) into the data. These views can range from an entire collection, to subsets of a collection, to a subset of a granule.
 - Consistent spatial and temporal resolution across each variable (i.e. array) within a virtual store
 - Uniform chunk grid and compression scheme across each variable within a virtual store
 - Chunk manifests are generated for a particular view and may span many granules

--- a/technical-features.qmd
+++ b/technical-features.qmd
@@ -7,10 +7,14 @@ subtitle: Additional information on technical features and their maturity levels
 
 **Current mature implementations share the following characteristics:**
 
-- Virtual stores are used to provide alternate views into data. These views can range from an entire collection, to subsets of a collection, to subsets of a granule.
+- Virtual stores are used to provide alternate views (defined below) into the data. These views can range from an entire collection, to subsets of a collection, to subsets of a granule.
 - Consistent spatial and temporal resolution across each variable (i.e. array) within a virtual store
 - Uniform chunk grid and compression scheme across each variable within a virtual store
-- Chunk manifest are generated for a particular view and may span many granules
+- Chunk manifests are generated for a particular view and may span many granules
+
+::: {.callout-note}
+We define the term "view" in a virtual store context to mean the different ways the same dataset can be represented. For example, a view of the same dataset could be representing the entire dataset as a cube or some a subset of the dataset, or a single variable array or a data tree of multiple groups of arrays. Different views will make sense given a datasets characteristics and the intended use cases.
+:::
 
 ## Supported data formats
 

--- a/technical-features.qmd
+++ b/technical-features.qmd
@@ -34,7 +34,7 @@ Custom parsers for additional formats can be implemented using the VirtualiZarr 
 
 ## Non-uniform grids
 
-Some NASA collections present additional complexity due having varying compression schemes and chunk grids across a logical array (usually across granules). At this point in time, Zarr assumes consistent chunk shape and compression across the entire array.
+Some NASA collections present additional complexity due to having varying compression schemes and chunk grids across a logical array (usually across granules). Currently, Zarr assumes a consistent chunk shape and compression across the entire array.
 
 However, support for both varying chunk shapes and compression schemes is in active development and should be available by summer 2026.
 


### PR DESCRIPTION
Both here and in #25, there is a misconception that virtual datasets should/must be done at the collection level (full collection aggregation). However, there are many benefits to aggregating subsets of collections, and potentially even subsets of individual granules. 

In #34, I describe ASF's mature OPERA DISP-S1 implementation, which aggregates at the tile/frame level, and our plans for NISAR, which will also aggregate at the tile/frame level.

So, I've taken a stab at rewording the "Mature Support" section to be more generic. I find it best to think of virtualization as a way to provide an alternate view into data. That may be a view of the entire collection, or a view of a subset.

Also, I found the "Unsupported data formats" section a bit weird since it only mentioned supported formats, so I've changed it to "Supported data formats".