### PR TITLE
Fix bullet points in executive summary.

### DIFF
--- a/executive-summary.qmd
+++ b/executive-summary.qmd
@@ -11,6 +11,7 @@ This report assesses the current state and future direction of virtual store tec
 Virtual store technology is ready for production use with consistently gridded data and is actively being developed for more complex data types.
 
 Key recommendations include:
+
 * adopting Icechunk (see [Technical Overview](./technical-overview.qmd))
 * adopting the GeoZarr standard (see [Technical Overview](./technical-overview.qmd))
 * planning for integration with other NASA services, such as EGIS and Harmony (see [NASA Ecosystem](./nasa-ecosystem.qmd)), and,


### PR DESCRIPTION
This incredibly minor PR just ensures that the bullet point in the key recommendations section of the executive summary are renders as bullet points. Currently, they just are smooshed together as a paragraph along with the prior line.

I'd also be totally fine with this change being put into #52.